### PR TITLE
added extension support to site info

### DIFF
--- a/lib/check.php
+++ b/lib/check.php
@@ -45,13 +45,18 @@ class check {
   
   static function infoIsWritable() {
     
+    $extension = 'txt';
+    if(c::get('content.file.extension')) {
+      $extension = c::get('content.file.extension');
+    }
+    
     if(c::get('lang.support')) {
-      $file = c::get('root.content') . '/site.' . c::get('lang.current') . '.txt';
+      $file = c::get('root.content') . '/site.' . c::get('lang.current') . '.' . $extension;
       if(!file_exists($file)) {
         return (!is_writable(dirname($file))) ? false : true;
       }
     } else {
-      $file = c::get('root.content') . '/site.txt';      
+      $file = c::get('root.content') . '/site.' . $extension;      
     }
     
     return (is_writable($file)) ? true : false;


### PR DESCRIPTION
when changing extension settings to something different than 'txt' you can't change site infos any more. check::infoIsWritable() returns false because it expects 'txt' as extension.

Using content/site.txt with changed extension setting won't display any info though... so I thought to add support for settings to check::infoIsWritable()
