### PR TITLE
Fixed addContent to work on XAMPP

### DIFF
--- a/lib/actions.php
+++ b/lib/actions.php
@@ -31,7 +31,7 @@ class action {
     
     if(get('add-page')) {
       $result = data::addContent();
-      if(success($result)) go($result['url'] . '/show:content');
+      if(success($result)) go($result['url'] . '/show' . c::get('uri.param.separator') . 'content');
     }
     
     return $result;


### PR DESCRIPTION
When adding new files on windows, the page would be created, but the panel would redirect to the error page due to the wrong param separator being used.
