### PR TITLE
$panel does not exist in this context

### DIFF
--- a/fields/date/date.php
+++ b/fields/date/date.php
@@ -4,4 +4,4 @@
 if(!isset($format)) $format = 'yy-mm-dd'; 
 
 ?>
-<input class="input" type="text" data-format="<?php echo html($format) ?>" data-language="<?php echo html($panel->user->language) ?>" name="<?php echo html($name) ?>" value="<?php echo html($value) ?>" />
+<input class="input" type="text" data-format="<?php echo html($format) ?>" data-language="<?php echo html($GLOBALS['panel']->user->language) ?>" name="<?php echo html($name) ?>" value="<?php echo html($value) ?>" />


### PR DESCRIPTION
date.php was throwing some warnings and producing the wrong attribute value. `$panel` isn't being passed to the field, so it needs to be pulled from the global scope one way or another.
