### PR TITLE
Hide template files

### DIFF
--- a/defaults/config/config.php
+++ b/defaults/config/config.php
@@ -21,3 +21,6 @@ c::set('upload.allowed', array(
   'application/gzip',
   'application/zip',
 ));
+
+// ignore template files
+c::set('template.file.ignore', array());

--- a/lib/check.php
+++ b/lib/check.php
@@ -62,6 +62,9 @@ class check {
     $templates  = dir::read(c::get('root.templates'));
     $blueprints = dir::read(c::get('root.site') . '/' . c::get('panel.folder') . '/blueprints');
 
+    // filter out ignored templates
+    $templates = array_diff($templates, c::get('template.file.ignore', array()));
+
     return array_diff($templates, $blueprints);
         
   }

--- a/lib/data.php
+++ b/lib/data.php
@@ -745,6 +745,9 @@ class data {
 
       $files = dir::read(c::get('root.site') . '/templates');
       
+      // filter out ignored templates
+      $files = array_diff($files, c::get('template.file.ignore', array()));
+      
       foreach($files as $file) {
 
         $name = f::name($file);


### PR DESCRIPTION
Allow named template files to be hidden, both from checks for
associated blueprints, and when adding new pages.

Inspired both by my own requirements, and http://getkirby.com/forum/panel/topic:273
