### PR TITLE
Fixed form->fieldtemplate to use kirby template

### DIFF
--- a/lib/form.php
+++ b/lib/form.php
@@ -146,10 +146,7 @@ class form {
   }
   
   function fieldtemplate($params) {
-    content::start();
-    extract($params);
-    require($file);
-    return content::end(true);      
+    return tpl::loadFile($params['file'], $params, true);
   }
   
   function fieldcss($options) {


### PR DESCRIPTION
updated `form->fieldtemplate` to use `tpl::loadFile` which includes global template vars (`$site`, `$panel`, `$pages`, and `$page`).
