### PR TITLE
Updated script to use safe array access instead of hiding notices

### DIFF
--- a/lib/form.php
+++ b/lib/form.php
@@ -75,12 +75,12 @@ class form {
       if(file_exists($js))  $this->js[$type]  = $js;
     
       // check for required fields
-      if(@$field['required'] == true) {
+      if(a::get($field, 'required', false) == true) {
         $this->required[$name] = $field;
       }
 
       // check for fields that need validation
-      if(@$field['validate'] != false) {
+      if(a::get($field, 'validate', false) != false) {
         $this->validate[$name] = $field;
       }
       


### PR DESCRIPTION
Instead of using the error control operator, the array should be accessed safely to avoid the errors entirely and provide good defaults.
