### PR TITLE
Only save fields with data

### DIFF
--- a/lib/data.php
+++ b/lib/data.php
@@ -683,7 +683,7 @@ class data {
       $v = a::get($input, $key);
       if(is_array($v)) {
         $data[$key] = implode(', ', $v);
-      } else {
+      } else if($v) {
         $data[$key] = trim($v);
       }
     }


### PR DESCRIPTION
I'm using a field to put sync buttons on a Kirby Panel page, but it's not an actual field.
This change discards any fields with an empty value or even without an input tag to keep the content files clean.
