### PR TITLE
Validation no longer forces fields to be required

### DIFF
--- a/lib/data.php
+++ b/lib/data.php
@@ -354,7 +354,7 @@ class data {
     }
 
     foreach($panel->form->validate as $key => $field) {
-      if(!self::validate($field['validate'], $data[$key])) $errors[$key] = $field;
+      if(isset($data[$key]) && !self::validate($field['validate'], $data[$key])) $errors[$key] = $field;
     }
                           
     if(!empty($errors)) {
@@ -683,7 +683,7 @@ class data {
       $v = a::get($input, $key);
       if(is_array($v)) {
         $data[$key] = implode(', ', $v);
-      } else {
+      } else if(trim($v)) {
         $data[$key] = trim($v);
       }
     }


### PR DESCRIPTION
Adding any validation rule to a field has an unintended side effect of making the field mandatory. `required: false` (the default) is no longer enforced.

This change fixes the problem (and resolves #28) by only running validation on fields with `required: false` when the field has a non-whitespace true value.
