### PR TITLE
Repositioning: pages.add and pages.delete into header

### DIFF
--- a/snippets/pages.php
+++ b/snippets/pages.php
@@ -52,9 +52,6 @@ $action   = action::sortPages($settings->flip);
   
 </div>
 
-<?php snippet('pages.add') ?>
-<?php snippet('pages.delete') ?>
-
 <?php else: ?>
 <div class="subpages">
 


### PR DESCRIPTION
Repositioning <?php snippet('pages.add') ?> and <?php snippet('pages.delete') ?> directly after <body> fixes the visibility of the modal window.
